### PR TITLE
normalize the query text before the query murmurhash is created. The …

### DIFF
--- a/packages/gatsby-source-graphql-universal/babel-plugin-remove-graphql-queries.js
+++ b/packages/gatsby-source-graphql-universal/babel-plugin-remove-graphql-queries.js
@@ -138,7 +138,8 @@ function getGraphQLTag(path) {
   }
 
   const text = quasis[0].value.raw;
-  const hash = murmurhash(text, `abc`);
+  const normalizedText = graphql.stripIgnoredCharacters(text);
+  const hash = murmurhash(normalizedText, `abc`);
 
   try {
     const ast = graphql.parse(text);
@@ -149,7 +150,7 @@ function getGraphQLTag(path) {
 
     return {
       ast,
-      text,
+      text: normalizedText,
       hash,
       isGlobal
     };


### PR DESCRIPTION
Query text normalization has been introduced to GatsbyJS 24 days ago also (see [this gatsby commit](https://github.com/gatsbyjs/gatsby/commit/752f5ff29008cd175b9a6608304b4f1da73c488c#diff-a46d7772b3756095c8e95b889d9b1df1)). Without the normalization the query ID is different and therefore the static queries do not work.

This change fixes the following reported issue in gatsby-source-prismic-graphql:
[birkir/gatsby-source-prismic-graphql#232](https://github.com/birkir/gatsby-source-prismic-graphql/issues/232)