### PR TITLE
fix: reactRuntime is not defined

### DIFF
--- a/packages/gatsby-source-graphql-universal/src/babel-loader.js
+++ b/packages/gatsby-source-graphql-universal/src/babel-loader.js
@@ -24,10 +24,11 @@ const { prepareOptions } = require(`./utils`);
 module.exports = babelLoader.custom(babel => {
   const toReturn = {
     // Passed the loader options.
-    customOptions({ stage = `test`, ...options }) {
+    customOptions({ stage = `test`, reactRuntime = 'classic', ...options }) {
       return {
         custom: {
           stage,
+          reactRuntime,
         },
         loader: {
           cacheDirectory: true,


### PR DESCRIPTION
Some gatsby users are reporting that they get an error reactRuntime is not defined. I would suggest not overriding our custom-babel-loader, instead create a babel-preset yourself.

Fixes: https://github.com/gatsbyjs/gatsby/issues/26736