### PR TITLE
fix: reactRuntime is not defined

### DIFF
--- a/packages/gatsby-source-graphql-universal/dist/babel-loader.js
+++ b/packages/gatsby-source-graphql-universal/dist/babel-loader.js
@@ -4,12 +4,10 @@ const babelLoader = require(`babel-loader`);
 
 const {
   getCustomOptions,
-  mergeConfigItemOptions
+  mergeConfigItemOptions,
 } = require(`gatsby/dist/utils/babel-loader-helpers`);
 
-const {
-  prepareOptions
-} = require(`./utils`);
+const { prepareOptions } = require(`./utils`);
 /**
  * Gatsby's custom loader for webpack & babel
  *
@@ -26,70 +24,69 @@ const {
  * You can find documentation for the custom loader here: https://babeljs.io/docs/en/next/babel-core.html#loadpartialconfig
  */
 
-
-module.exports = babelLoader.custom(babel => {
+module.exports = babelLoader.custom((babel) => {
   const toReturn = {
     // Passed the loader options.
-    customOptions({
-      stage = `test`,
-      ...options
-    }) {
+    customOptions({ stage = `test`, reactRuntime = `classic`, ...options }) {
       return {
         custom: {
-          stage
+          stage,
+          reactRuntime,
         },
         loader: {
           cacheDirectory: true,
           sourceType: `unambiguous`,
           ...getCustomOptions(stage),
-          ...options
-        }
+          ...options,
+        },
       };
     },
 
     // Passed Babel's 'PartialConfig' object.
-    config(partialConfig, {
-      customOptions
-    }) {
-      let {
-        options
-      } = partialConfig;
-      const [reduxPresets, reduxPlugins, requiredPresets, requiredPlugins, fallbackPresets] = prepareOptions(babel, customOptions); // If there is no filesystem babel config present, add our fallback
+    config(partialConfig, { customOptions }) {
+      let { options } = partialConfig;
+      const [
+        reduxPresets,
+        reduxPlugins,
+        requiredPresets,
+        requiredPlugins,
+        fallbackPresets,
+      ] = prepareOptions(babel, customOptions); // If there is no filesystem babel config present, add our fallback
       // presets/plugins.
 
       if (!partialConfig.hasFilesystemConfig()) {
-        options = { ...options,
+        options = {
+          ...options,
           plugins: requiredPlugins,
-          presets: [...fallbackPresets, ...requiredPresets]
+          presets: [...fallbackPresets, ...requiredPresets],
         };
       } else {
         // With a babelrc present, only add our required plugins/presets
-        options = { ...options,
+        options = {
+          ...options,
           plugins: [...options.plugins, ...requiredPlugins],
-          presets: [...options.presets, ...requiredPresets]
+          presets: [...options.presets, ...requiredPresets],
         };
       } // Merge in presets/plugins added from gatsby plugins.
 
-
-      reduxPresets.forEach(preset => {
+      reduxPresets.forEach((preset) => {
         options.presets = mergeConfigItemOptions({
           items: options.presets,
           itemToMerge: preset,
           type: `preset`,
-          babel
+          babel,
         });
       });
-      reduxPlugins.forEach(plugin => {
+      reduxPlugins.forEach((plugin) => {
         options.plugins = mergeConfigItemOptions({
           items: options.plugins,
           itemToMerge: plugin,
           type: `plugin`,
-          babel
+          babel,
         });
       });
       return options;
-    }
-
+    },
   };
   return toReturn;
 });


### PR DESCRIPTION
Some gatsby users are reporting that they get an error reactRuntime is not defined. I would suggest not overriding our custom-babel-loader, instead create a babel-preset yourself.

Fixes: https://github.com/gatsbyjs/gatsby/issues/26736
Fixes: #13